### PR TITLE
feat: add solar (sxp)

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -375,6 +375,12 @@
     "appName": "Stacks",
     "path": ["44'/5757'", "5757'", "888'/0'", "44'/1'"]
   },
+  "SXP": {
+    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},
+    "appName": "Solar",
+    "curve": ["secp256k1"],
+    "path": ["44'/3333'", "44'/1'"]
+  },
   "SecurityKey": {
     "appFlags": {"nanos2": "0x040", "nanox": "0x040"},
     "appName": "Security Key",


### PR DESCRIPTION
This PR proposes adding Solar (SXP) to the database.  
This also resolves support for the `guidelines_enforcer` workflow for `app-solar`.

• project: Solar (SXP)
• embedded app: https://github.com/LedgerHQ/app-solar
• coin type: `3333` (https://github.com/satoshilabs/slips/blob/master/slip-0044.md)