### PR TITLE
Update Avalanche variant

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -60,7 +60,7 @@
     "path": ["44'/118'", "44'/60'"]
   },
   "AVAX": {
-    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},
+    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Avalanche",
     "path": ["44'/9000'", "44'/60'"]
   },

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -62,6 +62,7 @@
   "AVAX": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Avalanche",
+    "curve": ["secp256k1"],
     "path": ["44'/9000'", "44'/60'"]
   },
   "AXL": {


### PR DESCRIPTION
We have a PR open (internally) to add support for the new Stax device to the Avalanche app, so we need to add the `appFlags` for it

See [CI job](https://github.com/ava-labs/ledger-avalanche/actions/runs/5260733809/jobs/9508055143?pr=190)