### PR TITLE
Update ZEC Variant

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -457,7 +457,7 @@
   "ZEC": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Zcash-new",
-    "curve": ["secp256k1"],
+    "curve": ["secp256k1", "ed25519"],
     "path": ["44'/133'"]
   },
   "ZTG": {


### PR DESCRIPTION
This adds the `ed25519` curve to the ZCash app, as is it used to generate the secrets for shielded addresses and transactions