### PR TITLE
Add missing curve to CACAO

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -103,6 +103,7 @@
   "CACAO": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "MAYAChain",
+    "curve": ["secp256k1"],
     "path": ["44'/931'"]
   },
   "CFG": {


### PR DESCRIPTION
Last time my commit was add to the repo I forgot to add the curve parameter to the CACAO asset.