### PR TITLE
Add "stax" flag to APTOS appFlags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -30,7 +30,7 @@
     "path": ["44'/283'"]
   },
   "APTOS": {
-    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},
+    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Aptos",
     "curve": ["ed25519"],
     "path": ["44'/637'"]


### PR DESCRIPTION
This is necessary to ensure compliance with Ledger guidelines for Ledger STAX.

PR: https://github.com/LedgerHQ/app-aptos/pull/13