### PR TITLE
Update flags for the Tezos baking app

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1733,7 +1733,7 @@
     "path": ["44'/330'"]
   },
   "tezos_baking": {
-    "appFlags": {"nanos": "0x800", "nanos2": "0xa40", "nanox": "0xa40", "stax": "0xa40"},
+    "appFlags": {"nanos": "0x240", "nanos2": "0x240", "nanox": "0x240", "stax": "0x240"},
     "appName": "Tezos Baking",
     "curve": ["ed25519", "secp256k1", "secp256r1"],
     "path": ["44'/1729'"]


### PR DESCRIPTION
 - Remove `LIBRARY` flag as the app is not called as a library
 - Set `BOLOS_SETTINGS` flag as the app needs lock screen settings
 - Set `GLOBAL_PIN` flag as the app needs pin validation