### PR TITLE
Remove `BOLOS_SETTINGS` flags for tezos baking app

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1733,7 +1733,7 @@
     "path": ["44'/330'"]
   },
   "tezos_baking": {
-    "appFlags": {"nanos": "0x240", "nanos2": "0x240", "nanox": "0x240", "stax": "0x240"},
+    "appFlags": {"nanos": "0x040", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
     "appName": "Tezos Baking",
     "curve": ["ed25519", "secp256k1", "secp256r1"],
     "path": ["44'/1729'"]


### PR DESCRIPTION
Remove `BOLOS_SETTINGS` for nanos and nanosp
Keep it for nanox and stax since `BLUETOOTH` is enabled