### PR TITLE
Update hathor appFlags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1040,7 +1040,7 @@
     "path": ["44'/60'"]
   },
   "hathor": {
-    "appFlags": {"nanos": "0x240", "nanos2": "0x240", "nanox": "0x240"},
+    "appFlags": {"nanos": "0x200", "nanos2": "0x200", "nanox": "0x200"},
     "appName": "Hathor",
     "curve": ["secp256k1"],
     "path": ["44'/280'/0'"]


### PR DESCRIPTION
`APPLICATION_FLAG_GLOBAL_PIN` (0x40) is not required by the app as of version 1.1.1 and has been removed from the Makefile.
