### PR TITLE
Update MimbleWimble Coin and MimbleWimble Coin Floonet appFlags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1261,13 +1261,13 @@
     "path": ["45'", "44'/60'", "44'/1'"]
   },
   "mimblewimble_coin": {
-    "appFlags": {"nanos": "0x800", "nanos2": "0x800", "nanox": "0xA00"},
+    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "MimbleWimble Coin",
     "curve": ["secp256k1"],
     "path": ["44'/593'"]
   },
   "mimblewimble_coin_floonet": {
-    "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},
+    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "MimbleWimble Coin Floonet",
     "curve": ["secp256k1"],
     "path": ["44'/1'"]


### PR DESCRIPTION
As per Quarkslab's recommendations during their audit of the MimbleWimble Coin app, this PR is to resolve the `guidelines_enforcer.yml` CI failing during the `Check APP_LOAD_PARAMS` stage for the MimbleWimble Coin app.

`APPLICATION_FLAG_LIBRARY` (0x800) is not required by the app as of version 7.2.0 and has been removed from the Makefile.

**Don't merge this PR yet since [Ledger's fork of the MimbleWimble Coin app ](https://github.com/LedgerHQ/app-mimblewimblecoin)is still on version 3.0.3**
