### PR TITLE
[flex] add both tezos-baking and tezos-wallet the appFlag flex

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1776,13 +1776,13 @@
     "path": ["44'/330'"]
   },
   "tezos_baking": {
-    "appFlags": {"nanos": "0x040", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
+    "appFlags": {"flex": "0x240", "nanos": "0x040", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
     "appName": "Tezos Baking",
     "curve": ["ed25519", "secp256k1", "secp256r1"],
     "path": ["44'/1729'"]
   },
   "tezos_wallet": {
-    "appFlags": {"nanos": "0x800", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"flex": "0xa00", "nanos": "0x800", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "Tezos Wallet",
     "curve": ["ed25519", "secp256k1", "secp256r1"],
     "path": ["44'/1729'"]


### PR DESCRIPTION
The flags for `flex` are currently the same as for `stax`