### PR TITLE
Add liquid and liquid_regtest

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1279,6 +1279,20 @@
     "curve": ["secp256k1"],
     "path": ["44'/60'"]
   },
+  "liquid": {
+    "appFlags": {"flex": "0x250", "nanos": "0x250", "nanos2": "0x250", "nanox": "0x250", "stax": "0x250"},
+    "appName": "Liquid",
+    "curve": ["secp256k1"],
+    "path": [null],
+    "path_slip21": ["LEDGER-Wallet policy", "SLIP-0077"]
+  },
+  "liquid_regtest": {
+    "appFlags": {"flex": "0x250", "nanos": "0x250", "nanos2": "0x250", "nanox": "0x250", "stax": "0x250"},
+    "appName": "Liquid Regtest",
+    "curve": ["secp256k1"],
+    "path": [null],
+    "path_slip21": ["LEDGER-Wallet policy", "SLIP-0077"]
+  },
   "lisk": {
     "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Lisk",


### PR DESCRIPTION
This PR is about adding support for the new **Liquid Network** application in two variants: "liquid" and "liquid_regtest".

Please pay attention to the `"path_slip21"` field that I have defined as:

`"path_slip21": ["LEDGER-Wallet policy", "SLIP-0077"]`

As I understand, using an array here would be non-standard, since all other apps define at most a single path. But I don't have a better idea, as the application really needs two SLIP-0021 paths for normal operation. The first one, `"LEDGER-Wallet policy"` is used to register non-standard wallets in the exactly same way as Bitcoin app does. The Liquid app is based on it and inherits this mechanism as is. Another path, `"SLIP-0077"` is used to derive the master blinding key from the seed.

Another potential issue is with the `"path"` field. Currently, it is defined in the same way as for the Bitcoin app:

`"path": [null]`

This is definitely not the best way from the side of potential security risks, as it grants the app the right to derive any possible key from the seed. I'd prefer to specify a more restricted list of paths, like:

`"path": ["44'/1'", "48'/1'", "49'/1'", "84'/1'", "86'/1'"]`

However, with the current SDK, AFAIK, there is no dedicated function returning master key fingerprint. So, like in Bitcoin app,   it is computed on the app side, requiring to derive the root pubkey.