### PR TITLE
Update XRP app flags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1935,7 +1935,7 @@
     "path": [null]
   },
   "xrp": {
-    "appFlags": {"flex": "0xa40", "nanos": "0xa40", "nanos2": "0xa40", "nanox": "0xa40", "stax": "0xa40"},
+    "appFlags": {"flex": "0xa00", "nanos": "0xa00", "nanos2": "0xa00", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "XRP",
     "curve": ["secp256k1", "ed25519"],
     "path": ["44'/144'"]


### PR DESCRIPTION
The app flags were incorrectly set on the [app-xrp](https://github.com/LedgerHQ/app-xrp). This PR updates the app flags to reflect the corrected flags in the app-xrp.

The following flag was commented out in the app-xrp Makefile.

`#HAVE_APPLICATION_FLAG_GLOBAL_PIN = 1` 

The PR in the app-xrp is [here](https://github.com/LedgerHQ/app-xrp/pull/62/commits/0637829dd644ec79a141648d0da0828cb05628a8). You can see the failed workflow [here](https://github.com/Transia-RnD/app-xrp/actions/runs/12073934939/job/33671148166?pr=4). 

This is the last task todo on a security audit so I really appreciate you taking a look at this. The security audit team has already reached out to Ledger to confirm this flag should be removed.

Thank You