### PR TITLE
Update XAH app flags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1917,7 +1917,7 @@
     "path": ["45'", "44'/77777'", "44'/1'"]
   },
   "xah": {
-    "appFlags": {"flex": "0xa40", "nanos2": "0xa40", "nanox": "0xa40", "stax": "0xa40"},
+    "appFlags": {"flex": "0xa00", "nanos2": "0xa00", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "XAH",
     "curve": ["secp256k1", "ed25519"],
     "path": ["44'/144'"]


### PR DESCRIPTION
We need to update the app flags for xah or Xahau network app. We removed the GLOBAL_PIN flag as it was unused. 

Thank you very much. 