### PR TITLE
disable lib for nanoS

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -54,7 +54,7 @@
     "path": ["44'/810'", "44'/354'"]
   },
   "ATOM": {
-    "appFlags": {"flex": "0xa00", "nanos": "0x800", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"flex": "0xa00", "nanos": "0x000", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "Cosmos",
     "curve": ["secp256k1"],
     "path": ["44'/118'", "44'/60'"]


### PR DESCRIPTION
- Device does not have enough space to hold the swap feature, so we can disable the lib feature