### PR TITLE
restore nanos for avalanche

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -78,7 +78,7 @@
     "path": ["44'/709'"]
   },
   "AVAX": {
-    "appFlags": {"flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
+    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Avalanche",
     "curve": ["secp256k1", "ed25519"],
     "path": ["44'/9000'", "44'/60'"]


### PR DESCRIPTION
Since Avalanche is not a new app, we need to continue supporting the NanoS device