### PR TITLE
Rebrand from eos to vaulta

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1020,9 +1020,9 @@
     "curve": ["secp256k1"],
     "path": ["44'/60'"]
   },
-  "eos": {
+  "vaulta": {
     "appFlags": {"flex": "0x240", "nanos": "0x240", "nanos2": "0x240", "nanox": "0x240", "stax": "0x240"},
-    "appName": "Eos",
+    "appName": "Vaulta",
     "curve": ["secp256k1"],
     "path": ["44'/194'"]
   },


### PR DESCRIPTION
EOS has rebranded to Vaulta.  Requesting update to match our rebrand

https://www.vaulta.com/resources/vaulta-token-swap-live
Bianance has announced support 
https://www.binance.com/en/support/announcement/detail/1e89a9ca957c4b0ca7502e60b993e201
FAQ on Rebrand
https://vaulta.gitbook.io/vaulta-guides/user-guides/support/faqs/vaulta