### PR TITLE
rebrand eos to vaulta, duplicate entry with new variant and appName

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1875,6 +1875,12 @@
     "curve": ["secp256k1"],
     "path": ["44'/60'"]
   },
+  "vaulta": {
+    "appFlags": {"flex": "0x240", "nanos": "0x240", "nanos2": "0x240", "nanox": "0x240", "stax": "0x240"},
+    "appName": "Vaulta",
+    "curve": ["secp256k1"],
+    "path": ["44'/194'"]
+  },
   "vechain": {
     "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "VeChain",


### PR DESCRIPTION
EOS has rebranded to Vaulta. Requesting update to match our rebrand. This PR duplicates the existing `eos` variant to a new name `vaulta` and a new appName `Vaulta`. We will submit an PR against our associated app with the updated names, and logos.

https://www.vaulta.com/resources/vaulta-token-swap-live
Bianance has announced support
https://www.binance.com/en/support/announcement/detail/1e89a9ca957c4b0ca7502e60b993e201
FAQ on Rebrand
https://vaulta.gitbook.io/vaulta-guides/user-guides/support/faqs/vaulta