### PR TITLE
Add BBAChain support

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"flex": "0x250", "nanos2": "0x800", "nanox": "0x250", "stax": "0x250"},
+    "appFlags": {"flex": "0x250", "nanos2": "0x250", "nanox": "0x250", "stax": "0x250"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
+    "appFlags": {"flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"flex": "0xa00", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"flex": "0x250", "nanos2": "0x800", "nanox": "0x250", "stax": "0x250"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -782,6 +782,12 @@
     "curve": ["ed25519"],
     "path": ["44'/198'"]
   },
+  "bbachain": {
+    "appFlags": {"nanos": "0x800"},
+    "appName": "BBAChain",
+    "curve": ["ed25519"],
+    "path": ["44'/829'"]
+  },
   "berachain": {
     "appFlags": {"flex": "0x800", "nanos2": "0x800", "nanox": "0x800", "stax": "0x800"},
     "appName": "Berachain",

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"flex": "0x250", "nanos2": "0x250", "nanox": "0x250", "stax": "0x250"},
+    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"nanos": "0x800"},
+    "appFlags": {"nanox": "0xa00", "flex": "0xa00", "stax": "0xa00"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -783,7 +783,7 @@
     "path": ["44'/198'"]
   },
   "bbachain": {
-    "appFlags": {"nanox": "0xa00", "flex": "0xa00", "stax": "0xa00"},
+    "appFlags": {"flex": "0xa00", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "BBAChain",
     "curve": ["ed25519"],
     "path": ["44'/829'"]


### PR DESCRIPTION
### Summary

This PR adds support for the **BBAChain** Ledger app to the `ledger-app-database` registry.

### Details

- **App name**: BBAChain  
- **Derivation path**: `44'/829'`  
- **Curve**: `ed25519`  
- **Supported devices**: `Nano S Plus`, `Nano X`, `Stax`, `Flex`  

Let us know if any additional information or formatting is needed.

Thanks!
