### PR TITLE
[tezos] remove the bls curve to the baking app params

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1854,7 +1854,7 @@
   "tezos_baking": {
     "appFlags": {"flex": "0x240", "nanos": "0x040", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
     "appName": "Tezos Baking",
-    "curve": ["ed25519", "secp256k1", "secp256r1", "bls12381g1"],
+    "curve": ["ed25519", "secp256k1", "secp256r1"],
     "path": ["44'/1729'"]
   },
   "tezos_wallet": {


### PR DESCRIPTION
Baking with BLS on Ledger is no longer a goal for Tezos.