### PR TITLE
[tezos] remove the nanos device to the baking app params

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -1852,7 +1852,7 @@
     "path": ["44'/330'"]
   },
   "tezos_baking": {
-    "appFlags": {"flex": "0x240", "nanos": "0x040", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
+    "appFlags": {"flex": "0x240", "nanos2": "0x040", "nanox": "0x240", "stax": "0x240"},
     "appName": "Tezos Baking",
     "curve": ["ed25519", "secp256k1", "secp256r1", "bls12381g1"],
     "path": ["44'/1729'"]


### PR DESCRIPTION
As it is deprecated by Ledger