### PR TITLE
Revert "Update celo app to support swap"

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -905,7 +905,7 @@
     "path": ["44'/60'"]
   },
   "celo": {
-    "appFlags": {"flex": "0xa00", "nanos": "0x800", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Celo",
     "curve": ["secp256k1"],
     "path": ["44'/52752'", "44'/60'/0'/0/0", "44'/60'/0'", "44'/60'/0'/0"]


### PR DESCRIPTION
This reverts commit 04bb809410012e2384948cf1067ae843705fc1c7.

We need to revert this change until the [fix](https://github.com/LedgerHQ/app-celo-spender/pull/32) for the token validation on the Celo app is merged. After that, we will open another PR to change the appFlags.