### PR TITLE
Add 0x10 to bitcoin_recovery flags

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -844,7 +844,7 @@
     "path": [null]
   },
   "bitcoin_recovery": {
-    "appFlags": {"apex_p": "0xa40", "flex": "0xa40", "nanos2": "0xa40", "nanox": "0xa40", "stax": "0xa40"},
+    "appFlags": {"apex_p": "0xa50", "flex": "0xa50", "nanos2": "0xa50", "nanox": "0xa50", "stax": "0xa50"},
     "appName": "Bitcoin Recovery",
     "curve": ["secp256k1"],
     "path": [null],


### PR DESCRIPTION
Since the app-bitcoin-new Bitcoin Recovery app was missing the HAVE_APPLICATION_FLAG_DERIVE_MASTER = 1 flag, which causes the Bitcoin Recovery app to reject custom unhardened derivation paths (this recovery variant is supposed to accept them), to add it back requires us to add 0x10 to the bitcoin_recovery app flags here which results in 0xa50.