### PR TITLE
Update app-load-params-db for Concordium Testnet

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -164,7 +164,7 @@
     "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Concordium",
     "curve": ["ed25519"],
-    "path": ["44'/919'", "1105'/0'"]
+    "path": ["44'/919'", "44'/1'", "1105'/0'"]
   },
   "CFG": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},


### PR DESCRIPTION
Updates the paths for Concordium app to allow Testnet `m/44'/1'` derivations.

Supports https://github.com/LedgerHQ/app-concordium/pull/33