### PR TITLE
Add Firmachain app parameters

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -288,6 +288,12 @@
     "curve": ["secp256k1"],
     "path": ["44'/60'"]
   },
+  "FIRMACHAIN": {
+    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appName": "Firmachain",
+    "curve": ["secp256k1"],
+    "path": ["44'/118'", "44'/7777777'"]
+  },
   "HIVE": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},
     "appName": "Hive",

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -265,7 +265,7 @@
     "path": ["44'/99999997'", "44'/354'"]
   },
   "FCT": {
-    "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Firmachain",
     "curve": ["secp256k1"],
     "path": ["44'/7777777'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -276,6 +276,12 @@
     "curve": ["secp256k1"],
     "path": ["44'/235'"]
   },
+  "FIRMACHAIN": {
+    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appName": "Firmachain",
+    "curve": ["secp256k1"],
+    "path": ["44'/118'", "44'/7777777'"]
+  },
   "FLOW": {
     "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Flow",
@@ -287,12 +293,6 @@
     "appName": "Flare Network",
     "curve": ["secp256k1"],
     "path": ["44'/60'"]
-  },
-  "FIRMACHAIN": {
-    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
-    "appName": "Firmachain",
-    "curve": ["secp256k1"],
-    "path": ["44'/118'", "44'/7777777'"]
   },
   "HIVE": {
     "appFlags": {"nanos": "0x000", "nanos2": "0x000", "nanox": "0x200"},

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -265,7 +265,7 @@
     "path": ["44'/99999997'", "44'/354'"]
   },
   "FCT": {
-    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "Firmachain",
     "curve": ["secp256k1"],
     "path": ["44'/7777777'"]

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -264,6 +264,12 @@
     "appName": "Equilibrium",
     "path": ["44'/99999997'", "44'/354'"]
   },
+  "FCT": {
+    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
+    "appName": "Firmachain",
+    "curve": ["secp256k1"],
+    "path": ["44'/7777777'"]
+  },
   "FIL": {
     "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Filecoin",
@@ -275,12 +281,6 @@
     "appName": "FIO",
     "curve": ["secp256k1"],
     "path": ["44'/235'"]
-  },
-  "FIRMACHAIN": {
-    "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
-    "appName": "Firmachain",
-    "curve": ["secp256k1"],
-    "path": ["44'/7777777'"]
   },
   "FLOW": {
     "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},

--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -280,7 +280,7 @@
     "appFlags": {"apex_p": "0xa00", "flex": "0xa00", "nanos2": "0x800", "nanox": "0xa00", "stax": "0xa00"},
     "appName": "Firmachain",
     "curve": ["secp256k1"],
-    "path": ["44'/118'", "44'/7777777'"]
+    "path": ["44'/7777777'"]
   },
   "FLOW": {
     "appFlags": {"flex": "0x200", "nanos": "0x000", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},


### PR DESCRIPTION
## Firmachain Ledger App - App Parameters Registration

**App repository:** https://github.com/FirmaChain/ledger-firmachain

**About Firmachain:**
  - Firmachain is a Cosmos SDK-based blockchain. Its coin type `7777777` is officially registered in SLIP-0044 as `FCT / FirmaChain`.
  
**Changes:**
  - Variant key: `FCT` (matches `COIN=FCT` / `VARIANT_VALUES=FCT` in the app Makefile)
  - App name: `Firmachain`
  - Derivation paths: `44'/7777777'` (Firmachain native)
  - Curve: `secp256k1`

  **Why path:**
  - `44'/7777777'`: Firmachain native coin type registered in SLIP-0044