### PR TITLE
Add secp256k1 to POLYX (Polymesh) curves

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -511,7 +511,7 @@
   "POLYX": {
     "appFlags": {"apex_p": "0x200", "flex": "0x200", "nanos2": "0x000", "nanox": "0x200", "stax": "0x200"},
     "appName": "Polymesh",
-    "curve": ["ed25519"],
+    "curve": ["ed25519", "secp256k1"],
     "path": ["44'/595'"]
   },
   "QUBIC": {


### PR DESCRIPTION
The Polymesh app supports both **Ed25519** and **secp256k1** derivation, but the `POLYX` entry only lists `ed25519`. This makes the mandatory `APP_LOAD_PARAMS` compliance check fail for the app, whose Makefile declares `CURVE_APP_LOAD_PARAMS = ed25519 secp256k1`.

secp256k1 is a first-class signing scheme in the app, selected via the APDU `P2` byte alongside ed25519:

- [`app/src/apdu_handler.c`](https://github.com/Zondax/ledger-polymesh-generic/blob/main/app/src/apdu_handler.c) accepts `P2 = secp256k1` for both `GetAddr` and `Sign`
- [`app/src/crypto.c`](https://github.com/Zondax/ledger-polymesh-generic/blob/main/app/src/crypto.c) implements `crypto_extractPublicKey_secp256k1` and `crypto_sign_secp256k1`

Verified with `scripts/app_load_params_check.py` against the app manifest generated by `scripts/makefile_dump.py`:

- against `main`: `[ERROR] Unexpected value for 'curve' (['ed25519', 'secp256k1'] vs ['ed25519'])` (exit 255)
- with this change: passes (exit 0)

No other field changes — `appName`, `appFlags` and `path` already match the app.

App repo: https://github.com/Zondax/ledger-polymesh-generic