### PR TITLE
Add Bitcoin Cash II

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -837,6 +837,12 @@
     "curve": ["secp256k1"],
     "path": ["*/145'", "*/0'", "4541509'", "45'"]
   },
+  "bitcoin_cash_ii": {
+    "appFlags": {"nanos2": "0x800"},
+    "appName": "Bitcoin Cash II",
+    "curve": ["secp256k1"],
+    "path": ["*/145'", "*/0'", "4541509'", "45'"]
+  },
   "bitcoin_clone_boilerplate": {
     "appFlags": {"apex_p": "0xa10", "flex": "0xa10", "nanos2": "0x810", "nanox": "0xa10", "stax": "0xa10"},
     "appName": "Bitcoin clone boilerplate",


### PR DESCRIPTION
Adds the `bitcoin_cash_ii` variant to `app-load-params-db.json`.

Bitcoin Cash II (BCH2) is a Bitcoin Cash protocol chain. The app is a clone of app-bitcoin-legacy: https://github.com/BitcoincashII/app-bitcoin-cash-ii

Generated with `scripts/app_load_params_gen_db.py --app_path <app> --database_path app-load-params-db.json`.