### PR TITLE
Add Bitcoin II app definition

### DIFF
--- a/app-load-params-db.json
+++ b/app-load-params-db.json
@@ -849,6 +849,13 @@
     "curve": ["secp256k1"],
     "path": ["*/156'", "*/0'", "4541509'", "45'"]
   },
+  "bitcoin_ii": {
+    "appFlags": {"apex_p": "0xa40", "flex": "0xa40", "nanos2": "0xa40", "nanox": "0xa40", "stax": "0xa40"},
+    "appName": "Bitcoin II",
+    "curve": ["secp256k1"],
+    "path": ["*/0'", "4541509'", "45'"],
+    "path_slip21": "LEDGER-Wallet policy"
+  },
   "bitcoin_legacy": {
     "appFlags": {"apex_p": "0xa10", "flex": "0xa10", "nanos2": "0x810", "nanox": "0xa10", "stax": "0xa10"},
     "appName": "Bitcoin Legacy",


### PR DESCRIPTION
## Summary

Add a Ledger application database entry for Bitcoin II.

## Details

This change adds the `bitcoin_ii` application definition to the Ledger app database.

Application parameters intentionally mirror the existing Bitcoin entry because Bitcoin II uses the same cryptographic curve, wallet policy support and Bitcoin-compatible derivation paths.

## Technical Information

- Application name: `Bitcoin II`
- Identifier: `bitcoin_ii`
- Curve: `secp256k1`
- Supported derivation paths:
  - Bitcoin-compatible coin type: `m/.../0'/...`
  - Bitcoin II coin type: `m/.../4541509'/...`
- SLIP-21 namespace: `LEDGER-Wallet policy`
- Device flags are identical to the Bitcoin application.

## References

- Bitcoin II website: https://bitcoin-ii.org/
- Bitcoin II Core: https://github.com/Bitcoin-II/BitcoinII-Core

## Validation

```bash
python3 scripts/app_load_params_lint.py \
  --database_path app-load-params-db.json \
  --check_lint \
  --check_appnames


Validation completed successfully.